### PR TITLE
Matplotlib backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   call-test-workflow:
-    uses: BlueBrain/Currentscape/.github/workflows/test.yml@main
+    uses: openbraininstitute/Currentscape/.github/workflows/test.yml@main
 
   build-tag-n-publish:
     name: Build, tag and publish on PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ We are providing support on `Gitter <https://gitter.im/openbraininstitute/Curren
 Main dependencies
 =================
 
-- `Python 3.8+ <https://www.python.org/downloads/release/python-380/>`_
+- `Python 3.9+ <https://www.python.org/downloads/release/python-390/>`_
 - `Numpy <https://numpy.org/>`_ (automatically installed by pip)
 - `Palettable <https://github.com/jiffyclub/palettable>`_ (automatically installed by pip)
 

--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,7 @@ We wish to thank the authors of `Alonso and Marder, 2019 <https://doi.org/10.755
 The part of the code in this repository developed by the EPFL Blue Brain Project was supported by funding to the Blue Brain Project, a research center of the École polytechnique fédérale de Lausanne (EPFL), from the Swiss government's ETH Board of the Swiss Federal Institutes of Technology.
 
 Copyright (c) 2023-2024 Blue Brain Project/EPFL
+
 Copyright (c) 2025 Open Brain Institute
 
 

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Currentscape figures plot the percentage of inward and outward ionic membrane cu
 the total inward and outward currents, as well as the voltage in function of time.
 It allows modellers to see which currents play a role at any given time during a simulation, and check in depth the current dynamics.
 
-.. image:: https://raw.githubusercontent.com/BlueBrain/Currentscape/main/doc/source/images/plot.png
+.. image:: https://raw.githubusercontent.com/openbraininstitute/Currentscape/main/doc/source/images/plot.png
 
 Citation
 ========
@@ -70,7 +70,7 @@ When you use this Currentscape software for your research, we ask you to cite th
 Support
 =======
 
-We are providing support on `Gitter <https://gitter.im/BlueBrain/Currentscape>`_. We suggest you create tickets on the `Github issue tracker <https://github.com/BlueBrain/Currentscape/issues>`_ in case you encounter problems while using the software or if you have some suggestions.
+We are providing support on `Gitter <https://gitter.im/openbraininstitute/Currentscape>`_. We suggest you create tickets on the `Github issue tracker <https://github.com/openbraininstitute/Currentscape/issues>`_ in case you encounter problems while using the software or if you have some suggestions.
 
 Main dependencies
 =================
@@ -209,7 +209,7 @@ When you then execute the following python code, a window should open with the c
 
 When you run this code in Python, it will generate the following currentscape plot (in a window, and on disk as quickstart_plot.png):
 
-.. image:: https://raw.githubusercontent.com/BlueBrain/Currentscape/main/doc/source/images/quickstart_plot.png
+.. image:: https://raw.githubusercontent.com/openbraininstitute/Currentscape/main/doc/source/images/quickstart_plot.png
 
 Tutorial
 ========
@@ -229,6 +229,7 @@ We wish to thank the authors of `Alonso and Marder, 2019 <https://doi.org/10.755
 The part of the code in this repository developed by the EPFL Blue Brain Project was supported by funding to the Blue Brain Project, a research center of the École polytechnique fédérale de Lausanne (EPFL), from the Swiss government's ETH Board of the Swiss Federal Institutes of Technology.
 
 Copyright (c) 2023-2024 Blue Brain Project/EPFL
+Copyright (c) 2025 Open Brain Institute
 
 
 .. |pypi| image:: https://img.shields.io/pypi/v/currentscape.svg
@@ -240,20 +241,20 @@ Copyright (c) 2023-2024 Blue Brain Project/EPFL
                :alt: latest documentation
 
 .. |license| image:: https://img.shields.io/pypi/l/currentscape.svg
-                  :target: https://github.com/BlueBrain/Currentscape/blob/main/LICENSE.txt
+                  :target: https://github.com/openbraininstitute/Currentscape/blob/main/LICENSE.txt
                   :alt: license
 
-.. |build| image:: https://github.com/BlueBrain/Currentscape/workflows/test.yml/badge.svg?branch=main
-                :target: https://github.com/BlueBrain/Currentscape/actions
+.. |build| image:: https://github.com/openbraininstitute/Currentscape/workflows/test.yml/badge.svg?branch=main
+                :target: https://github.com/openbraininstitute/Currentscape/actions
                 :alt: actions build status
 
-.. |coverage| image:: https://codecov.io/github/BlueBrain/Currentscape/coverage.svg?branch=main
-                   :target: https://codecov.io/gh/BlueBrain/currentscape
+.. |coverage| image:: https://codecov.io/github/openbraininstitute/Currentscape/coverage.svg?branch=main
+                   :target: https://codecov.io/gh/openbraininstitute/currentscape
                    :alt: coverage
 
 .. |gitter| image:: https://badges.gitter.im/Join%20Chat.svg
-                 :target: https://gitter.im/BlueBrain/Currentscape
-                 :alt: Join the chat at https://gitter.im/BlueBrain/Currentscape
+                 :target: https://gitter.im/openbraininstitute/Currentscape
+                 :alt: Join the chat at https://gitter.im/openbraininstitute/Currentscape
 
 .. |zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.8046484.svg
                 :target: https://doi.org/10.5281/zenodo.8046373

--- a/Tutorial.rst
+++ b/Tutorial.rst
@@ -300,7 +300,7 @@ Run cell and plot Currentscape
 ==============================
 
 You can see an example of how to extract currents and ionic concentractions with bluepyopt and emodelrunner in the example folder: :code:`examples/use_case`.
-Please note that you should have `bluepyopt <https://github.com/BlueBrain/BluePyOpt>`_, `emodelrunner <https://github.com/BlueBrain/EModelRunner>`_ and `NEURON <https://neuron.yale.edu/neuron/>`_ installed in order to run the example.
+Please note that you should have `bluepyopt <https://github.com/openbraininstitute/BluePyOpt>`_, `emodelrunner <https://github.com/BlueBrain/EModelRunner>`_ and `NEURON <https://neuron.yale.edu/neuron/>`_ installed in order to run the example.
 The example folder contains
 a cell,
 a script to run the cell by applying to it a step stimulus and record its voltage, current and ionic concentration traces,

--- a/currentscape/currents.py
+++ b/currentscape/currents.py
@@ -22,9 +22,7 @@ that are under the CC0 1.0 Universal (CC0 1.0) Public Domain Dedication license.
 # pylint: disable=wrong-import-position, super-with-arguments
 import math
 import numpy as np
-import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 import matplotlib.pyplot as plt
 
 from currentscape.datasets import DataSet

--- a/currentscape/currentscape.py
+++ b/currentscape/currentscape.py
@@ -22,9 +22,7 @@ that are under the CC0 1.0 Universal (CC0 1.0) Public Domain Dedication license.
 # pylint: disable=too-many-statements, wrong-import-position
 import logging
 import numpy as np
-import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 import matplotlib.pyplot as plt
 
 from currentscape.data_processing import (

--- a/currentscape/ions.py
+++ b/currentscape/ions.py
@@ -16,9 +16,7 @@
 
 # pylint: disable=wrong-import-position, super-with-arguments
 import numpy as np
-import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 import matplotlib.pyplot as plt
 
 from currentscape.datasets import DataSet

--- a/currentscape/legends.py
+++ b/currentscape/legends.py
@@ -18,7 +18,6 @@
 
 import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 from matplotlib.legend_handler import HandlerTuple
 
 from currentscape.mapper import map_colors

--- a/currentscape/plotting.py
+++ b/currentscape/plotting.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import numpy as np
 import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 import matplotlib.pyplot as plt
 
 import palettable as pltb

--- a/currentscape/voltages.py
+++ b/currentscape/voltages.py
@@ -16,9 +16,7 @@
 
 # pylint: disable=wrong-import-position, super-with-arguments
 import numpy as np
-import matplotlib
 
-matplotlib.use("agg")  # to avoid tkinter error
 import matplotlib.pyplot as plt
 
 from currentscape.datasets import DataSet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers=[
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ example = ["scipy", "bluepyopt", "emodelrunner>=1.2.5"]
 
 
 [project.urls]
-Homepage = "https://github.com/BlueBrain/Currentscape"
-Source = "https://github.com/BlueBrain/Currentscape"
-Repository = "https://github.com/BlueBrain/Currentscape.git"
-Tracker = "https://github.com/BlueBrain/Currentscape/issues"
+Homepage = "https://github.com/openbraininstitute/Currentscape"
+Source = "https://github.com/openbraininstitute/Currentscape"
+Repository = "https://github.com/openbraininstitute/Currentscape.git"
+Tracker = "https://github.com/openbraininstitute/Currentscape/issues"
 Documentation = "https://currentscape.readthedocs.io/en/latest"
 
 [tool.setuptools.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,10 @@ ignore_basepython_conflict = true
 
 [gh-actions]
 python =
-    3.8: py3
     3.9: py3
     3.10: py3
     3.11: py3
-    3.12: check-packaging, lint, docs, coverage
+    3.12: py3, check-packaging, lint, docs, coverage
 
 [testenv]
 basepython=python


### PR DESCRIPTION
- update github links from BlueBrain to openbraininstitute
- remove python 3.8 tests and support
- add openbraininstitute copyright
- stop using matplotlib agg backend because:
    - It prevents from using plt.show()
    - Also currentscape should not arbitrarly set the matplotlib backend. That is the user to decide what to use