### PR TITLE
pass on codecov secret when test.yml is called from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   call-test-workflow:
     uses: openbraininstitute/Currentscape/.github/workflows/test.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build-tag-n-publish:
     name: Build, tag and publish on PyPI


### PR DESCRIPTION
The build.yml github action called when a PR is merged fails, and I think this PR should solve the issue.